### PR TITLE
Add HUD toggle shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Current features:
 - Paste your track schema
 - Auto layout - enter number of straight and curved pieces in your collection and see what layout is possible
 - Keyboard shortcuts
+- Toggle HUD with <kbd>H</kbd>
 
 Upcoming features:
 - Add more track pieces

--- a/components/HelpModal.vue
+++ b/components/HelpModal.vue
@@ -33,7 +33,8 @@ const shortcuts = [
     items: [
       { keys: ['Cmd/Ctrl', '0'], description: 'Reset zoom and center view' },
       { keys: ['Mouse Wheel'], description: 'Zoom in/out' },
-      { keys: ['Click + Drag'], description: 'Pan the view' }
+      { keys: ['Click + Drag'], description: 'Pan the view' },
+      { keys: ['H'], description: 'Toggle HUD visibility' }
     ]
   },
   {

--- a/components/TrackEditor.vue
+++ b/components/TrackEditor.vue
@@ -84,21 +84,25 @@ onUnmounted(() => {
   <div>
     <canvas ref="canvas" id="trackCanvas" class="border border-gray-300 block"></canvas>
     
-    <ControlPanel
-      v-if="showHud"
-      :copy-status="copyStatus"
-      :is-delete-mode="isDeleteMode"
-      :on-add-straight="addStraight"
-      :on-add-curve="addCurve"
-      :on-enable-delete-mode="enableDeleteMode"
+    <transition name="control-panel">
+      <ControlPanel
+        v-if="showHud"
+        :copy-status="copyStatus"
+        :is-delete-mode="isDeleteMode"
+        :on-add-straight="addStraight"
+        :on-add-curve="addCurve"
+        :on-enable-delete-mode="enableDeleteMode"
       :on-undo="undoLastAction"
       :on-copy="copyLayout"
       :on-paste="() => handlePaste(loadLayout)"
-      :on-clear="clearPieces"
-      :on-show-auto-layout="() => showAutoLayout = true"
-    />
+        :on-clear="clearPieces"
+        :on-show-auto-layout="() => showAutoLayout = true"
+      />
+    </transition>
 
-    <HelpButton v-if="showHud" @click="showHelp = true" />
+    <transition name="help-button">
+      <HelpButton v-if="showHud" @click="showHelp = true" />
+    </transition>
 
     <AutoLayoutModal 
       :show="showAutoLayout"
@@ -111,3 +115,35 @@ onUnmounted(() => {
     <HelpModal :show="showHelp" @close="() => showHelp = false" />
   </div>
 </template>
+
+<style scoped>
+.control-panel-enter-from,
+.control-panel-leave-to {
+  transform: translateX(calc(-100% - 1rem));
+  opacity: 0;
+}
+.control-panel-enter-to,
+.control-panel-leave-from {
+  transform: translateX(0);
+  opacity: 1;
+}
+.control-panel-enter-active,
+.control-panel-leave-active {
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.help-button-enter-from,
+.help-button-leave-to {
+  transform: translateX(calc(100% + 1rem));
+  opacity: 0;
+}
+.help-button-enter-to,
+.help-button-leave-from {
+  transform: translateX(0);
+  opacity: 1;
+}
+.help-button-enter-active,
+.help-button-leave-active {
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+</style>

--- a/components/TrackEditor.vue
+++ b/components/TrackEditor.vue
@@ -8,6 +8,7 @@ import HelpModal from './HelpModal.vue';
 const canvas = ref(null);
 const copyStatus = ref('');
 const showHelp = ref(false);
+const showHud = ref(true);
 
 // Auto-layout generation state
 const straightCount = ref(8);
@@ -37,6 +38,13 @@ const {
 const { handlePaste } = useClipboard(copyStatus);
 
 function handleGlobalKeyDown(e: KeyboardEvent) {
+  // Handle HUD toggle
+  if ((e.key === 'h' || e.key === 'H') && !e.ctrlKey && !e.metaKey) {
+    e.preventDefault();
+    showHud.value = !showHud.value;
+    return;
+  }
+
   // Handle help modal toggle
   if (e.key === '?' && !e.ctrlKey && !e.metaKey) {
     e.preventDefault();
@@ -77,6 +85,7 @@ onUnmounted(() => {
     <canvas ref="canvas" id="trackCanvas" class="border border-gray-300 block"></canvas>
     
     <ControlPanel
+      v-if="showHud"
       :copy-status="copyStatus"
       :is-delete-mode="isDeleteMode"
       :on-add-straight="addStraight"
@@ -89,7 +98,7 @@ onUnmounted(() => {
       :on-show-auto-layout="() => showAutoLayout = true"
     />
 
-    <HelpButton @click="showHelp = true" />
+    <HelpButton v-if="showHud" @click="showHelp = true" />
 
     <AutoLayoutModal 
       :show="showAutoLayout"


### PR DESCRIPTION
## Summary
- add HUD visibility flag and `H` key toggle
- hide ControlPanel and HelpButton when HUD is off
- document keyboard shortcut in help modal and README

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68835a9bbe608322a4cf127f60d8fbec