### PR TITLE
Fix connection indicator generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ logs
 .env
 .env.*
 !.env.example
+node-compile-cache

--- a/composables/trackPieces/connections.ts
+++ b/composables/trackPieces/connections.ts
@@ -866,10 +866,11 @@ export function validateLayout(pieces: TrackPiece[]): { isValid: boolean; errors
  */
 export function getConnectionIndicators(pieces: TrackPiece[]): ConnectionPoint[] {
   const allConnections: ConnectionPoint[] = [];
-  
+
   for (const piece of pieces) {
     const connections = getConnectionPoints(piece);
+    allConnections.push(...connections);
   }
-  
+
   return allConnections;
 }


### PR DESCRIPTION
## Summary
- include connection points when generating connection indicator list
- ignore node-compile-cache directory

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_688358e08b448322869e4a40dd44bcee