### PR TITLE
Fix connection point indicators

### DIFF
--- a/composables/trackPieces/connections.ts
+++ b/composables/trackPieces/connections.ts
@@ -866,10 +866,11 @@ export function validateLayout(pieces: TrackPiece[]): { isValid: boolean; errors
  */
 export function getConnectionIndicators(pieces: TrackPiece[]): ConnectionPoint[] {
   const allConnections: ConnectionPoint[] = [];
-  
+
   for (const piece of pieces) {
     const connections = getConnectionPoints(piece);
+    allConnections.push(...connections);
   }
-  
+
   return allConnections;
 }


### PR DESCRIPTION
## Summary
- append returned connection points in `getConnectionIndicators`

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68838b9b6f848322beb1e4f66b8ef1bc