### PR TITLE
Add track piece count HUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Current features:
 - Rotate pieces
 - Flip pieces
 - Ghost piece to see the placement and orientation
+- Track piece count showing number of straights and curves placed (including loaded layouts)
 - Undo track placement
 - Copy your track schema
 - Paste your track schema

--- a/components/ControlPanel.vue
+++ b/components/ControlPanel.vue
@@ -4,6 +4,7 @@ import { computed } from 'vue';
 interface Props {
   copyStatus?: string;
   isDeleteMode?: boolean;
+  pieceCounts?: Record<string, number>;
   onAddStraight?: () => void;
   onAddCurve?: () => void;
   onEnableDeleteMode?: () => void;
@@ -78,7 +79,7 @@ const buttonClasses: Record<ButtonClass, string> = {
 
 <template>
   <div class="fixed top-4 left-4 flex flex-col gap-2">
-    <button 
+    <button
       v-for="button in controlButtons"
       :key="button.label"
       @click="button.action"
@@ -87,5 +88,8 @@ const buttonClasses: Record<ButtonClass, string> = {
       {{ button.label }}
     </button>
     <span class="text-sm text-gray-600">{{ copyStatus }}</span>
+    <div v-if="pieceCounts" class="text-sm text-gray-600">
+      Straights: {{ pieceCounts.straight }} | Curves: {{ pieceCounts.curve }}
+    </div>
   </div>
 </template>

--- a/components/TrackEditor.vue
+++ b/components/TrackEditor.vue
@@ -29,10 +29,12 @@ const {
   clearPieces,
   isDeleteMode,
   showConnectionPoints,
+  pieceCounts,
 } = useTrackEditor({
   canvas,
   copyStatus,
 });
+
 
 // Use clipboard composable
 const { handlePaste } = useClipboard(copyStatus);
@@ -89,6 +91,7 @@ onUnmounted(() => {
         v-if="showHud"
         :copy-status="copyStatus"
         :is-delete-mode="isDeleteMode"
+        :piece-counts="pieceCounts"
         :on-add-straight="addStraight"
         :on-add-curve="addCurve"
         :on-enable-delete-mode="enableDeleteMode"

--- a/composables/useTrackEditor.ts
+++ b/composables/useTrackEditor.ts
@@ -1,4 +1,4 @@
-import { ref, type Ref } from '#imports';
+import { ref, computed, type Ref } from '#imports';
 import { 
   renderTrackPiece, 
   findSnapPosition, 
@@ -17,6 +17,14 @@ interface UseTrackEditorOptions {
 
 export function useTrackEditor({ canvas, copyStatus }: UseTrackEditorOptions) {
   const pieces = ref<TrackPiece[]>([]);
+  const pieceCounts = computed(() => {
+    const counts: Record<string, number> = {};
+    for (const p of pieces.value) {
+      if (!p.type) continue;
+      counts[p.type] = (counts[p.type] || 0) + 1;
+    }
+    return counts;
+  });
   const zoom = ref(1);
   let offsetX = 0;
   let offsetY = 0;
@@ -849,5 +857,6 @@ export function useTrackEditor({ canvas, copyStatus }: UseTrackEditorOptions) {
     cleanup,
     generateAutoLayout,
     loadLayout,
+    pieceCounts,
   };
 }


### PR DESCRIPTION
## Summary
- count track pieces in useTrackEditor
- expose counts so TrackEditor can show them in the HUD
- document that counts include loaded layouts

## Testing
- `pnpm install`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6883d7483d248322972a708f0580ecc0